### PR TITLE
Track server metrics for all endpoints, remove high cardinality path label

### DIFF
--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -1,32 +1,19 @@
 from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 from flask import request
 
+import mlflow
+
 
 def activate_prometheus_exporter(app):
-    metrics = GunicornInternalPrometheusMetrics(app, export_defaults=False)
+    def mlflow_version(req: request):
+        return mlflow.__version__
 
-    endpoint = app.view_functions
-    histogram = metrics.histogram(
-        "mlflow_requests_by_status_and_path",
-        "Request latencies and count by status and path",
-        labels={
-            "status": lambda r: r.status_code,
-            "path": lambda: change_path_for_metric(request.path),
-        },
+    metrics = GunicornInternalPrometheusMetrics(
+        app, 
+        export_defaults=True, 
+        defaults_prefix="mlflow",
+        excluded_paths=["/health"],
+        group_by=mlflow_version
     )
-    for func_name, func in endpoint.items():
-        if func_name in ["_search_runs", "_log_metric", "_log_param", "_set_tag", "_create_run"]:
-            app.view_functions[func_name] = histogram(func)
 
     return app
-
-
-def change_path_for_metric(path):
-    """
-    Replace the '/' in the metric path by '_' so grafana can correctly use it.
-    :param path: path of the metric (example: runs/search)
-    :return: path with '_' instead of '/'
-    """
-    if "mlflow/" in path:
-        path = path.split("mlflow/")[-1]
-    return path.replace("/", "_")

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -1,12 +1,11 @@
 from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 from flask import request
 
-import mlflow
-
+from mlflow.version import VERSION
 
 def activate_prometheus_exporter(app):
     def mlflow_version(req: request):
-        return mlflow.__version__
+        return VERSION
 
     metrics = GunicornInternalPrometheusMetrics(
         app,

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -5,7 +5,7 @@ from mlflow.version import VERSION
 
 
 def activate_prometheus_exporter(app):
-    def mlflow_version(req: request):  # noqa: W0613
+    def mlflow_version(req: request):  # pylint: disable=unused-argument
         return VERSION
 
     metrics = GunicornInternalPrometheusMetrics(

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -3,8 +3,9 @@ from flask import request
 
 from mlflow.version import VERSION
 
+
 def activate_prometheus_exporter(app):
-    def mlflow_version(req: request):
+    def mlflow_version(req: request):  # noqa: W0613
         return VERSION
 
     metrics = GunicornInternalPrometheusMetrics(

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -9,11 +9,11 @@ def activate_prometheus_exporter(app):
         return mlflow.__version__
 
     metrics = GunicornInternalPrometheusMetrics(
-        app, 
-        export_defaults=True, 
+        app,
+        export_defaults=True,
         defaults_prefix="mlflow",
         excluded_paths=["/health"],
-        group_by=mlflow_version
+        group_by=mlflow_version,
     )
 
-    return app
+    return metrics

--- a/tests/server/test_prometheus_exporter.py
+++ b/tests/server/test_prometheus_exporter.py
@@ -1,0 +1,50 @@
+import os
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import pytest
+
+from mlflow.server.prometheus_exporter import activate_prometheus_exporter
+
+tmpdir = TemporaryDirectory()
+
+
+@pytest.fixture()
+def app():
+    from mlflow.server import app
+
+    ctx = app.app_context()
+    ctx.push()
+    yield app
+    ctx.pop()
+
+
+@mock.patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": tmpdir.name})
+def test_metrics(app):
+    metrics = activate_prometheus_exporter(app)
+    metric_labels = {"method": "GET", "status": "200"}
+
+    with app.test_client() as c:
+        assert (
+            metrics.registry.get_sample_value("mlflow_http_request_total", labels=metric_labels)
+            is None
+        )
+        c.get("/")
+        assert (
+            metrics.registry.get_sample_value("mlflow_http_request_total", labels=metric_labels)
+            == 1
+        )
+
+        # calling the metrics endpoint should not increment the counter
+        c.get("/metrics")
+        assert (
+            metrics.registry.get_sample_value("mlflow_http_request_total", labels=metric_labels)
+            == 1
+        )
+
+        # calling the health endpoint should not increment the counter
+        c.get("/health")
+        assert (
+            metrics.registry.get_sample_value("mlflow_http_request_total", labels=metric_labels)
+            == 1
+        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the Prometheus metrics exporter to observe all Flask endpoints (except for the healthcheck) and uses the default metrics to track request count and latencies. The path label is removed from metrics due to its high cardinality (its a best practice to keep label cardinality < 10 but mlflow has ~50 different endpoints).

Metrics have three labels: HTTP method, HTTP status, and mlflow version.
